### PR TITLE
Convert string values for $use_crontab to bool

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,8 @@ class systemupdates (
   validate_string($hour)
   validate_string($minute)
   validate_bool($auto_reboot)
-  validate_bool($use_crontab)
+  $_use_crontab = str2bool($use_crontab)
+  validate_bool($_use_crontab)
   if $exclude {
     validate_array($exclude)
   }


### PR DESCRIPTION
This will allow string values to be used for `use_crontab`. This is useful because older versions of hiera can interpolate values of any data type but the resulting values are converted to a string.